### PR TITLE
Generate file name if needed.

### DIFF
--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
@@ -11,8 +11,7 @@
           type="text"
           ref="noteName"
           v-model="note.name"
-          placeholder="Your note name"
-          required>
+          placeholder="Your note name">
         </b-input>
       </b-field>
 

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
@@ -7,6 +7,15 @@
   import languages from '@/assets/data/languages.json';
   import converter from '@/converter';
 
+  const noteNameCharacters = "abcdef0123456789";
+
+  const generateNoteName = () => {
+    let text = "";
+    for (let i = 0; i < 32; i += 1)
+      text += noteNameCharacters.charAt(Math.floor(Math.random() * 16));
+    return text;
+  };
+
   export default {
     name: 'cn-create-note-modal',
     components: { editor },
@@ -44,20 +53,28 @@
       createNote() {
         if (!this.containsDupFiles()) {
           let separator = '-';
+          let prefix = 'note';
 
           if (this.gistsSelected) {
             separator = '.';
+            prefix = 'gist';
           }
 
-          this.files.forEach(file => {
+          let name;
+          this.files.forEach((file, i) => {
+            name = file.name || `${prefix}file${(i + 1)}`;
             this.note.files[
-              `${file.name}${separator}${converter.languageToExtension(
+              `${name}${separator}${converter.languageToExtension(
                 file.language
               )}`
             ] = file;
           });
           this.note.createdAt = new Date();
           this.note.updatedAt = new Date();
+
+          if (!this.note.name || this.note.name.trim() === "") {
+            this.note.name = `${prefix}:${generateNoteName()}`;
+          }
 
           this.addNote(this.note).then(() => {
             this.$parent.close();
@@ -98,25 +115,8 @@
     computed: {
       ...mapGetters(['gistsSelected']),
       isDisabled() {
-        if (this.gistsSelected) {
-          return this.files.some(
-            file =>
-              !/^[^.]*$/.test(file.name) ||
-              !/\S/.test(file.name) ||
-              !/\S/.test(file.language) ||
-              !/\S/.test(file.content)
-          );
-        }
-
-        return (
-          !/\S/.test(this.note.name) ||
-          this.files.some(
-            file =>
-              !/^[^.]*$/.test(file.name) ||
-              !/\S/.test(file.name) ||
-              !/\S/.test(file.language) ||
-              !/\S/.test(file.content)
-          )
+        return this.files.some(
+          file => !/\S/.test(file.content)
         );
       },
     },

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
@@ -137,25 +137,8 @@
     computed: {
       ...mapGetters(['gistsSelected']),
       isDisabled() {
-        if (this.gistsSelected) {
-          return this.files.some(
-            file =>
-              !/^[^.]*$/.test(file.name) ||
-              !/\S/.test(file.name) ||
-              !/\S/.test(file.language) ||
-              !/\S/.test(file.content)
-          );
-        }
-
-        return (
-          !/\S/.test(this.note.name) ||
-          this.files.some(
-            file =>
-              !/^[^.]*$/.test(file.name) ||
-              !/\S/.test(file.name) ||
-              !/\S/.test(file.language) ||
-              !/\S/.test(file.content)
-          )
+        return this.files.some(
+          file => !/\S/.test(file.content)
         );
       },
     },


### PR DESCRIPTION
Here is my suggestion to tackle issue https://github.com/lauthieb/code-notes/issues/48 .

I'm doing just like GitHub for its gists:
- if there is no note name, generate one randomly `note:{32 hexadecimal characters}`
- if there is no file name `notefile1` or `gistfile1` and so on...