### PR TITLE
Export to carbon-sh

### DIFF
--- a/src/renderer/components/notes-list/note-card/NoteCard.html
+++ b/src/renderer/components/notes-list/note-card/NoteCard.html
@@ -37,6 +37,9 @@
                  title="Copy to clipboard">
                 <b-icon icon="clipboard"></b-icon>
               </a>
+              <a id="export-carbon" @click="exportToCarbon(value.content)" title="Export to Carbon">
+                <b-icon icon="image"></b-icon>
+              </a>
             </span>
           </h4>
           <editor :code="value.content"

--- a/src/renderer/components/notes-list/note-card/NoteCard.scss
+++ b/src/renderer/components/notes-list/note-card/NoteCard.scss
@@ -68,6 +68,13 @@
         color: lighten($black, 20%);
       }
     }
+    #export-carbon {
+      color: $dark;
+   
+      &:hover {
+        color: lighten($black, 20%);
+      }
+    }
   }
 }
 

--- a/src/renderer/components/notes-list/note-card/NoteCard.vue
+++ b/src/renderer/components/notes-list/note-card/NoteCard.vue
@@ -61,6 +61,10 @@ export default {
     open(link) {
       this.$electron.shell.openExternal(link);
     },
+    exportToCarbon(content) {
+      let url = `https://carbon.now.sh/?bg=rgba(0,0,0,0)&t=dracula&l=auto&ds=true&wc=true&wa=true&pv=43px&ph=57px&ln=false&code=`;
+      this.$electron.shell.openExternal(`${url}${encodeURI(content)}`)
+    }
   },
 };
 </script>


### PR DESCRIPTION
I added an icon (a picture icon) beside each note that, when clicked, will open up a new browser window pointing to an instance of https://carbon.now.sh containing the code from the note.