### PR TITLE
fix(bug): Issue with periods in filenames

### DIFF
--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
@@ -51,26 +51,18 @@ export default {
     ...mapActions(['addNote']),
     createNote() {
       if (!this.containsDupFiles()) {
-        let separator = '-';
-        let prefix = 'note';
+        const noteType = this.getNoteType();
 
-        if (this.gistsSelected) {
-          separator = '.';
-          prefix = 'gist';
-        }
-
-        let name;
         this.files.forEach((file, i) => {
-          name = file.name || `${prefix}file${i + 1}`;
-          this.note.files[
-            `${name}${separator}${converter.languageToExtension(file.language)}`
-          ] = file;
+          const filename = file.name || `${noteType}file${i + 1}`;
+          const key = converter.filenameToKey(filename, file.language, noteType);
+          this.note.files[key] = file;
         });
         this.note.createdAt = new Date();
         this.note.updatedAt = new Date();
 
         if (!this.note.name || this.note.name.trim() === '') {
-          this.note.name = `${prefix}:${generateNoteName()}`;
+          this.note.name = `${noteType}:${generateNoteName()}`;
         }
 
         this.addNote(this.note).then(() => {
@@ -95,9 +87,7 @@ export default {
       let dupFiles = false;
 
       this.files.forEach(file => {
-        const key = `${file.name}.${converter.languageToExtension(
-          file.language
-        )}`;
+        const key = converter.filenameToKey(file.name, file.language, this.getNoteType());
 
         if (map.has(key)) {
           dupFiles = true;
@@ -107,6 +97,9 @@ export default {
       });
 
       return dupFiles;
+    },
+    getNoteType() {
+      return (this.gistsSelected) ? 'gist' : 'note';
     },
   },
   computed: {

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
@@ -59,9 +59,7 @@ export default {
           });
 
           this.gistFiles.forEach((file, index) => {
-            const key = `${
-              this.gistFiles[index].name
-            }.${converter.languageToExtension(this.gistFiles[index].language)}`;
+            const key = converter.filenameToKey(file.name, file.language, this.getNoteType());
 
             if (file.deleted) {
               this.noteUpdated.files[key] = null;
@@ -82,7 +80,8 @@ export default {
           });
         } else {
           this.files.forEach(file => {
-            this.noteUpdated.files[file.name] = file;
+            const key = converter.filenameToKey(file.name, file.language, this.getNoteType());
+            this.noteUpdated.files[key] = file;
           });
           this.noteUpdated.updatedAt = new Date();
         }
@@ -119,10 +118,7 @@ export default {
       let dupFiles = false;
 
       this.files.forEach(file => {
-        const key = `${file.name}.${converter.languageToExtension(
-          file.language
-        )}`;
-
+        const key = converter.filenameToKey(file.name, file.language, this.getNoteType());
         if (map.has(key)) {
           dupFiles = true;
         }
@@ -131,6 +127,9 @@ export default {
       });
 
       return dupFiles;
+    },
+    getNoteType() {
+      return (this.gistsSelected) ? 'gist' : 'note';
     },
   },
   computed: {

--- a/src/renderer/converter.js
+++ b/src/renderer/converter.js
@@ -1,6 +1,19 @@
 import languages from './assets/data/languages';
 
 const converter = {
+  filenameToKey(filename, language, type = 'note') {
+    // Build separator by type
+    const separator = (type === 'gist') ? '.' : '-';
+
+    // Sanitize name for disallowed nedb characters
+    // list of disallowed characters taken from https://github.com/louischatriot/nedb/issues/477
+    let name = filename;
+    if (type === 'note' && typeof name === 'string') {
+      name = name.replace(/[.$]/, '_');
+    }
+
+    return `${name}${separator}${this.languageToExtension(language)}`;
+  },
   languageToExtension(language) {
     if (languages.filter(l => l.name === language).length > 0) {
       return languages.filter(l => l.name === language)[0].extension;


### PR DESCRIPTION
Closes #59

Resolves issue with disallowed nedb characters. Noticed that this was broken on update as well, so created a method in `converter` to convert a file into a nedb-compatible key.

This ballooned a bit more than I expected. Hopefully everything fits convention - please let me know if there's something I need to change.