### PR TITLE
Add vuex-cache package and cache gists loading.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14929,6 +14929,11 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
       "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
+    "vuex-cache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vuex-cache/-/vuex-cache-3.1.0.tgz",
+      "integrity": "sha512-XDzQ/jddmErZVquyHhbOHc6DPhVSt5bU8433Fzsai3XydU3cxyYTUd3PH2Ww5sesB9yu5f0wKk6MFIqgjSa3Yw=="
+    },
     "w3c-blob": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/w3c-blob/-/w3c-blob-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "vue-clipboard2": "0.0.8",
     "vue-electron": "^1.0.6",
     "vue-router": "^3.0.2",
-    "vuex": "^3.1.0"
+    "vuex": "^3.1.0",
+    "vuex-cache": "^3.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.25.0",

--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -1,10 +1,12 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import createCache from 'vuex-cache';
 
 import modules from './modules';
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
+  plugins: [createCache()],
   modules,
 });

--- a/src/renderer/store/modules/Note.js
+++ b/src/renderer/store/modules/Note.js
@@ -183,7 +183,7 @@ const actions = {
   },
   selectGists(store, gists) {
     store.commit('SELECT_GISTS', gists);
-    store.dispatch('loadNotes');
+    store.cache.dispatch('loadNotes');
   },
 };
 


### PR DESCRIPTION
Hi!

I've added a new package to handle the caching of the gists loading on every switch from local to gists mentioned in #96 .
The package is named `vuex-cache` and it has no dependencies.


Right now there is no reload button yet, but you can actually force a reload by just saving the access token again. Maybe this is already good enough for now?