### PR TITLE
Fix: address whiteout issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14696,26 +14696,6 @@
         "prepend-http": "^1.0.1"
       }
     },
-    "vue-router": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
-      "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
-    },
-    "vue-style-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
-      "integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
-      "dev": true,
-      "requires": {
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.0.2"
-      }
-    },
-    "vue-select": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
-      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -15132,6 +15112,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+    },
+    "vue-select": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
+      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
     },
     "vue-style-loader": {
       "version": "3.1.2",

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
@@ -11,7 +11,8 @@
           type="text"
           ref="noteName"
           v-model="note.name"
-          placeholder="Your note name">
+          placeholder="Your note name"
+          required>
         </b-input>
       </b-field>
 
@@ -20,7 +21,8 @@
           type="text"
           ref="noteDescription"
           v-model="note.description"
-          placeholder="Your description">
+          placeholder="Your description"
+          required>
         </b-input>
       </b-field>
 
@@ -44,7 +46,8 @@
             style="width: 186px"
             type="text"
             v-model="file.name"
-            placeholder="Your file name">
+            placeholder="Your file name"
+            required>
           </b-input>
           <p class="control is-pulled-right" v-if="files.length > 1">
             <button class="button is-danger" @click="deleteFile(file)">

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
@@ -115,20 +115,20 @@ export default {
 
       if(this.getNoteType() === "gist"){
         if(this.files.some(file => !/\S/.test(file.content))   ||
-         this.files.some(file => !/\S/.test(file.name))      ||
-         this.files.some(file => !/\S/.test(this.note.description))){
-           isCreateButtonDisabled = true;
+           this.files.some(file => !/\S/.test(file.name))      ||
+           this.files.some(file => !/\S/.test(this.note.description))){
+               isCreateButtonDisabled = true;
          } else {
-           isCreateButtonDisabled = false;
+               isCreateButtonDisabled = false;
          }
       } if(this.getNoteType() === "note"){
           if(this.files.some(file => !/\S/.test(file.content))   ||
-          this.files.some(file => !/\S/.test(file.name))      ||
-          this.files.some(file => !/\S/.test(this.note.name)) ||
-          this.files.some(file => !/\S/.test(this.note.description))){
-            isCreateButtonDisabled = true;
+             this.files.some(file => !/\S/.test(file.name))      ||
+             this.files.some(file => !/\S/.test(this.note.name)) ||
+             this.files.some(file => !/\S/.test(this.note.description))){
+                 isCreateButtonDisabled = true;
           } else {
-            isCreateButtonDisabled = false;
+                 isCreateButtonDisabled = false;
           }
       }
       return isCreateButtonDisabled;

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
@@ -111,7 +111,27 @@ export default {
   computed: {
     ...mapGetters(['gistsSelected', 'notes']),
     isDisabled() {
-      return this.files.some(file => !/\S/.test(file.content));
+      let isCreateButtonDisabled = false;
+
+      if(this.getNoteType() === "gist"){
+        if(this.files.some(file => !/\S/.test(file.content))   ||
+         this.files.some(file => !/\S/.test(file.name))      ||
+         this.files.some(file => !/\S/.test(this.note.description))){
+           isCreateButtonDisabled = true;
+         } else {
+           isCreateButtonDisabled = false;
+         }
+      } if(this.getNoteType() === "note"){
+          if(this.files.some(file => !/\S/.test(file.content))   ||
+          this.files.some(file => !/\S/.test(file.name))      ||
+          this.files.some(file => !/\S/.test(this.note.name)) ||
+          this.files.some(file => !/\S/.test(this.note.description))){
+            isCreateButtonDisabled = true;
+          } else {
+            isCreateButtonDisabled = false;
+          }
+      }
+      return isCreateButtonDisabled;
     },
     sortedLanguagesByUse() {
       this.languages.forEach((language) => { language.frequency = 0; });

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.html
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.html
@@ -21,7 +21,8 @@
           type="text"
           ref="noteDescription"
           v-model="noteUpdated.description"
-          placeholder="Your description">
+          placeholder="Your description"
+          required>
         </b-input>
       </b-field>
 
@@ -38,7 +39,8 @@
             style="width: 186px"
             type="text"
             v-model="file.name"
-            placeholder="Your file name">
+            placeholder="Your file name"
+            required>
           </b-input>
           <p class="control is-pulled-right" v-if="files.length > 1">
             <button class="button is-danger" @click="deleteFile(file)">

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
@@ -135,7 +135,27 @@ export default {
   computed: {
     ...mapGetters(['gistsSelected']),
     isDisabled() {
-      return this.files.some(file => !/\S/.test(file.content));
+      let isCreateButtonDisabled = false;
+
+      if(this.getNoteType() === "gist"){
+        if(this.files.some(file => !/\S/.test(file.content))   ||
+           this.files.some(file => !/\S/.test(file.name))      ||
+           this.files.some(file => !/\S/.test(this.noteUpdated.description))){
+               isCreateButtonDisabled = true;
+         } else {
+               isCreateButtonDisabled = false;
+         }
+      } if(this.getNoteType() === "note"){
+          if(this.files.some(file => !/\S/.test(file.content))   ||
+             this.files.some(file => !/\S/.test(file.name))      ||
+             this.files.some(file => !/\S/.test(this.noteUpdated.name)) ||
+             this.files.some(file => !/\S/.test(this.noteUpdated.description))){
+                 isCreateButtonDisabled = true;
+          } else {
+                 isCreateButtonDisabled = false;
+          }
+      }
+      return isCreateButtonDisabled;
     },
   },
 };


### PR DESCRIPTION
I am updating the modals to inhibit the create buttons if the text input boxes are not filled in. I also need to update the update note modal. I'll let you know when I am done.

This addresses #119 strangely enough it looks like is only an issue with local notes, and only on windows. I tried to recreate on linux/mac with no luck. Regardless I think the create button shouldn't be enabled until all text input is filled in, if anyone have any other thoughts I am all ears. :)