### PR TITLE
Uninstall-configuration for Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14696,26 +14696,6 @@
         "prepend-http": "^1.0.1"
       }
     },
-    "vue-router": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
-      "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
-    },
-    "vue-style-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
-      "integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
-      "dev": true,
-      "requires": {
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.0.2"
-      }
-    },
-    "vue-select": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
-      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -15132,6 +15112,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+    },
+    "vue-select": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
+      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
     },
     "vue-style-loader": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,11 @@
       "icon": "build/icons/icon.icns"
     },
     "win": {
+      "target": "nsis",
       "icon": "build/icons/icon.ico"
+    },
+    "nsis": {
+      "deleteAppDataOnUninstall": true
     },
     "linux": {
       "icon": "build/icons"


### PR DESCRIPTION
This takes care of the data left behind on windows as per issue #124 

There shouldn't be any data left behind on mac/linux as dmg/appimage are self-contained applications and deleting them should do the trick.

Data will not delete on a new install, only when clicking the `Uninstall Code Notes.exe`  which is the desired end goal.