### PR TITLE
Added menu item with shortcut for dev tools in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14696,26 +14696,6 @@
         "prepend-http": "^1.0.1"
       }
     },
-    "vue-router": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
-      "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
-    },
-    "vue-style-loader": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.1.2.tgz",
-      "integrity": "sha512-ICtVdK/p+qXWpdSs2alWtsXt9YnDoYjQe0w5616j9+/EhjoxZkbun34uWgsMFnC1MhrMMwaWiImz3K2jK1Yp2Q==",
-      "dev": true,
-      "requires": {
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.0.2"
-      }
-    },
-    "vue-select": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
-      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -15132,6 +15112,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
+    },
+    "vue-select": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-3.2.0.tgz",
+      "integrity": "sha512-FfARbDuJWQNpYm6X9zPWCsYXmz33TNR2oqY8FktKRVksKfp1tZPqL9g+/7wgsaMaqUxcIxYEUVV7C3AD+H5cxA=="
     },
     "vue-style-loader": {
       "version": "3.1.2",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -45,7 +45,7 @@ function createWindow() {
         },
         { type: 'separator' },
         {
-          label: 'Dev Tools',
+          label: 'Toggle dev tools',
           accelerator: 'CmdOrCtrl+Shift+I',
           click: () => {
             mainWindow.openDevTools();

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -48,7 +48,7 @@ function createWindow() {
           label: 'Toggle dev tools',
           accelerator: 'CmdOrCtrl+Shift+I',
           click: () => {
-            mainWindow.openDevTools();
+            mainWindow.toggleDevTools();
           },
         },
         {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -45,6 +45,13 @@ function createWindow() {
         },
         { type: 'separator' },
         {
+          label: 'Dev Tools',
+          accelerator: 'CmdOrCtrl+Shift+I',
+          click: () => {
+            mainWindow.openDevTools();
+          },
+        },
+        {
           label: 'Quit',
           accelerator: 'Command+Q',
           click: () => {

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.html
@@ -11,7 +11,8 @@
           type="text"
           ref="noteName"
           v-model="note.name"
-          placeholder="Your note name">
+          placeholder="Your note name"
+          required>
         </b-input>
       </b-field>
 
@@ -20,7 +21,8 @@
           type="text"
           ref="noteDescription"
           v-model="note.description"
-          placeholder="Your description">
+          placeholder="Your description"
+          required>
         </b-input>
       </b-field>
 
@@ -44,7 +46,8 @@
             style="width: 186px"
             type="text"
             v-model="file.name"
-            placeholder="Your file name">
+            placeholder="Your file name"
+            required>
           </b-input>
           <p class="control is-pulled-right" v-if="files.length > 1">
             <button class="button is-danger" @click="deleteFile(file)">
@@ -55,7 +58,7 @@
 
         <b-field horizontal label="Language">
           <v-select style="width: 186px" label="name" :options="sortedLanguagesByUse" placeholder="Select a language"
-             v-model="file.language" :reduce="selectedLanguage => selectedLanguage.name">
+             v-model="file.language" :reduce="selectedLanguage => selectedLanguage.name" :clearable="false">
              <template v-slot:option="option">
                {{ option.name | capitalize }}
              </template>

--- a/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
+++ b/src/renderer/components/modals/create-note-modal/CreateNoteModal.vue
@@ -111,7 +111,18 @@ export default {
   computed: {
     ...mapGetters(['gistsSelected', 'notes']),
     isDisabled() {
-      return this.files.some(file => !/\S/.test(file.content));
+      const isGistDisabled = () => (
+        !/\S/.test(this.note.description) ||
+        this.files.some(file => !/\S/.test(file.name)) ||
+        this.files.some(file => !/\S/.test(file.language)) ||
+        this.files.some(file => !/\S/.test(file.content))
+      );
+
+      const isNoteDisabled = () => (
+        isGistDisabled() || !/\S/.test(this.note.name)
+      );
+
+      return this.gistsSelected ? isGistDisabled() : isNoteDisabled();
     },
     sortedLanguagesByUse() {
       this.languages.forEach((language) => { language.frequency = 0; });

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.html
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.html
@@ -21,7 +21,8 @@
           type="text"
           ref="noteDescription"
           v-model="noteUpdated.description"
-          placeholder="Your description">
+          placeholder="Your description"
+          required>
         </b-input>
       </b-field>
 
@@ -38,7 +39,8 @@
             style="width: 186px"
             type="text"
             v-model="file.name"
-            placeholder="Your file name">
+            placeholder="Your file name"
+            required>
           </b-input>
           <p class="control is-pulled-right" v-if="files.length > 1">
             <button class="button is-danger" @click="deleteFile(file)">
@@ -48,7 +50,7 @@
         </b-field>
 
         <b-field horizontal label="Language">
-          <b-select placeholder="Select a language" v-model="file.language">
+          <b-select placeholder="Select a language" v-model="file.language" :clearable="false">
             <option
               v-for="language in languages"
               :value="language.name">

--- a/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
+++ b/src/renderer/components/modals/update-note-modal/UpdateNoteModal.vue
@@ -135,7 +135,18 @@ export default {
   computed: {
     ...mapGetters(['gistsSelected']),
     isDisabled() {
-      return this.files.some(file => !/\S/.test(file.content));
+      const isGistDisabled = () => (
+        !/\S/.test(this.noteUpdated.description) ||
+        this.files.some(file => !/\S/.test(file.name)) ||
+        this.files.some(file => !/\S/.test(file.language)) ||
+        this.files.some(file => !/\S/.test(file.content))
+      );
+
+      const isNoteDisabled = () => (
+        isGistDisabled() || !/\S/.test(this.noteUpdated.name)
+      );
+
+      return this.gistsSelected ? isGistDisabled() : isNoteDisabled();
     },
   },
 };


### PR DESCRIPTION
As per @lnrdnl [comment](https://github.com/lauthieb/code-notes/issues/119#issuecomment-563919412) I've went ahead and added a menu item to launch dev tools in the production app. This will help in the long run to debug app from a user standpoint. This used to be on by default, but was disabled at some point by electron package hence the menu item now.

CTRL/CMD+SHIFT+I, it also under Application/Dev Tools menu