### PR TITLE
Fixing bug vue-cli 4 upgrade with existing database

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -27,6 +27,7 @@ module.exports = {
     electronBuilder: {
       nodeIntegration: true,
       mainProcessFile: "src/background.js",
+      externals: ['nedb'],
       builderOptions: {
         // options placed here will be merged with default configuration and passed to electron-builder
         productName: "Code Notes",


### PR DESCRIPTION
Marking **nedb** as external, to use the external file instead of IndexedDB.

Source: https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/307

Resolves #94 Bug with existing Database