### PR TITLE
fix modal confirm window

### DIFF
--- a/src/components/notes-list/note-card/NoteCard.vue
+++ b/src/components/notes-list/note-card/NoteCard.vue
@@ -131,7 +131,7 @@ export default {
       this.updateNote(this.note);
     },
     deleteNoteModal() {
-      this.$dialog.confirm({
+      this.$buefy.dialog.confirm({
         title: this.gistsSelected ? "Delete gist" : "Delete note",
         message: `Are you sure you want to delete this ${
           this.gistsSelected ? "gist" : "note"


### PR DESCRIPTION
Fixes #142 

Buefy implemented a new way to call the confirm window - see https://buefy.org/documentation/dialog/#confirm